### PR TITLE
Add notice on main page regarding transition from EG

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,13 @@ becoming familiar with the roles in which you are most impacted.  These roles ar
 If you find gaps in our documentation, please open an issue (or better yet, a pull request) on the
 Gateway Provisioners `Github repo <https://github.com/gateway-experiments/gateway_provisioners>`_.
 
+.. note::
+   The following pages are still in transition from the `Jupyter Enterprise Gateway repository
+   <https://github.com/jupyter-server/enterprise_gateway>`_.  As a result, you will find information that pertains
+   to Enterprise Gateway, but really has no application relative to Gateway Provisioners.
+   Please bear with us in these busy (and exciting) times!
+
+
 Table of Contents
 -----------------
 


### PR DESCRIPTION
The docs are still in transition from EG so this pull request lets folks know that there may be unrelated information.

This note should be removed as part of #43.