### PR TITLE
Initial test framework and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,13 +77,13 @@ jobs:
 
   test_minimum_versions:
     name: Test Minimum Versions
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
-          python_version: "3.8"
+          python_version: "3.9"
       - uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Run the unit tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,14 +98,14 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/make-sdist@v1
 
-#  test_sdist:
-#    name: Install from SDist and Test
-#    runs-on: ubuntu-latest
-#    needs: [make_sdist]
-#    timeout-minutes: 20
-#    steps:
-#      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-#      - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
+  test_sdist:
+    name: Install from SDist and Test
+    runs-on: ubuntu-latest
+    needs: [make_sdist]
+    timeout-minutes: 20
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
 
   python_tests_check: # This job does nothing and is only used for the branch protection
     name: Check Jobs
@@ -115,7 +115,7 @@ jobs:
       - link_check
       - test_minimum_versions
       - build_docs
-#      - test_sdist
+      - test_sdist
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,19 +75,20 @@ jobs:
       - name: Build Docs
         run: make docs
 
-  test_minimum_versions:
-    name: Test Minimum Versions
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-        with:
-          python_version: "3.9"
-      - uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
-      - name: Run the unit tests
-        run: |
-          make test
+# Disabled for now, timed out after 20 and 30 minute attempts
+#  test_minimum_versions:
+#    name: Test Minimum Versions
+#    timeout-minutes: 20
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+#        with:
+#          python_version: "3.9"
+#      - uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+#      - name: Run the unit tests
+#        run: |
+#          make test
 
   make_sdist:
     name: Make SDist
@@ -113,7 +114,7 @@ jobs:
     needs:
       - build
       - link_check
-      - test_minimum_versions
+      # - test_minimum_versions
       - build_docs
       - test_sdist
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ lint: build-dependencies ## check style with flake8
 	pre-commit run --all-files
 
 test: ## run tests quickly with the default Python
-	@echo "No tests exist!"
-# 	pytest -v --cov gateway_provisioners gateway_provisioners
+	pytest -v --cov tests tests
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	hatch run docs:api

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ lint: build-dependencies ## check style with flake8
 	pre-commit run --all-files
 
 test: ## run tests quickly with the default Python
-	pytest -v --cov tests tests
+	hatch run test:test
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	hatch run docs:api

--- a/gateway_provisioners/container.py
+++ b/gateway_provisioners/container.py
@@ -4,7 +4,7 @@
 import os
 import signal
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Set
 
 import urllib3  # docker ends up using this and it causes lots of noise, so turn off warnings
 from jupyter_client import localinterfaces
@@ -70,7 +70,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
         return self.container_name is not None
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         # Unset assigned_host, ip, and node_ip in pre-launch, otherwise, these screw up restarts
         self.assigned_host = ""
         self.assigned_ip = None
@@ -91,7 +91,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
         return kwargs
 
     @overrides
-    def log_kernel_launch(self, cmd: list[str]) -> None:
+    def log_kernel_launch(self, cmd: List[str]) -> None:
         self.log.info(
             f"{self.__class__.__name__}: kernel launched. Kernel image: {self.image_name}, "
             f"KernelID: {self.kernel_id}, cmd: '{cmd}'"
@@ -198,7 +198,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
                 self.detect_launch_failure()
 
     @overrides
-    async def get_provisioner_info(self) -> dict[str, Any]:
+    async def get_provisioner_info(self) -> Dict[str, Any]:
         """Captures the base information necessary for kernel persistence relative to containers."""
         provisioner_info = await super().get_provisioner_info()
         provisioner_info.update(
@@ -215,7 +215,7 @@ class ContainerProvisionerBase(RemoteProvisionerBase):
         self.assigned_node_ip = provisioner_info.get("assigned_node_ip")
 
     @abstractmethod
-    def get_initial_states(self) -> set[str]:
+    def get_initial_states(self) -> Set[str]:
         """Return list of states indicating container is starting (includes running)."""
         raise NotImplementedError
 

--- a/gateway_provisioners/distributed.py
+++ b/gateway_provisioners/distributed.py
@@ -9,7 +9,8 @@ import signal
 import subprocess
 import warnings
 from socket import gethostbyname, gethostname
-from typing import Any, Optional
+from typing import Any, Dict, Optional
+from typing import List as tyList
 
 import paramiko
 from jupyter_client import KernelConnectionInfo, launch_kernel
@@ -101,7 +102,7 @@ class DistributedProvisioner(RemoteProvisionerBase):
         )
 
     @validate("load_balancing_algorithm")
-    def _validate_load_balancing_algorithm(self, proposal: dict[str, str]) -> str:
+    def _validate_load_balancing_algorithm(self, proposal: Dict[str, str]) -> str:
         value = proposal["value"]
         try:
             assert value in ["round-robin", "least-connection"]
@@ -135,7 +136,7 @@ class DistributedProvisioner(RemoteProvisionerBase):
         return self.local_proc is not None or (self.ip is not None and self.pid > 0)
 
     @overrides
-    async def launch_kernel(self, cmd: list[str], **kwargs: Any) -> KernelConnectionInfo:
+    async def launch_kernel(self, cmd: tyList[str], **kwargs: Any) -> KernelConnectionInfo:
         """
         Launches a kernel process on a selected host.
 
@@ -216,14 +217,14 @@ class DistributedProvisioner(RemoteProvisionerBase):
                 ready_to_connect = await self.receive_connection_info()
 
     @overrides
-    def log_kernel_launch(self, cmd: list[str]) -> None:
+    def log_kernel_launch(self, cmd: tyList[str]) -> None:
         self.log.info(
             f"{self.__class__.__name__}: kernel launched.  Host: '{self.assigned_host}', "
             f"pid: {self.pid}, Kernel ID: {self.kernel_id}, "
             f"Log file: {self.assigned_host}:{self.kernel_log}, cmd: '{cmd}'."
         )
 
-    def _launch_remote_process(self, cmd: list[str], **kwargs: Any):
+    def _launch_remote_process(self, cmd: tyList[str], **kwargs: Any):
         """
         Launch the kernel as indicated by the argv stanza in the kernelspec.  Note that this method
         will bypass use of ssh if the remote host is also the local machine.
@@ -248,7 +249,7 @@ class DistributedProvisioner(RemoteProvisionerBase):
 
         return result_pid
 
-    def _build_startup_command(self, cmd: list[str], **kwargs: Any) -> list[str]:
+    def _build_startup_command(self, cmd: tyList[str], **kwargs: Any) -> tyList[str]:
         """
         Builds the command to invoke by concatenating envs from kernelspec followed by the kernel argvs.
 

--- a/gateway_provisioners/docker_swarm.py
+++ b/gateway_provisioners/docker_swarm.py
@@ -3,7 +3,7 @@
 """Code related to managing kernels running in docker-based containers."""
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Set
 
 from overrides import overrides
 
@@ -38,7 +38,7 @@ class DockerSwarmProvisioner(ContainerProvisionerBase):
         self.client = DockerClient.from_env()
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         kwargs = await super().pre_launch(**kwargs)
 
         # Convey the network to the docker launch script
@@ -47,7 +47,7 @@ class DockerSwarmProvisioner(ContainerProvisionerBase):
         return kwargs
 
     @overrides
-    def get_initial_states(self) -> set[str]:
+    def get_initial_states(self) -> Set[str]:
         return {"preparing", "starting", "running"}
 
     @overrides
@@ -164,7 +164,7 @@ class DockerProvisioner(ContainerProvisionerBase):
         self.client = DockerClient.from_env()
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         kwargs = await super().pre_launch(**kwargs)
 
         # Convey the network to the docker launch script
@@ -173,7 +173,7 @@ class DockerProvisioner(ContainerProvisionerBase):
         return kwargs
 
     @overrides
-    def get_initial_states(self) -> set[str]:
+    def get_initial_states(self) -> Set[str]:
         return {"created", "running"}
 
     @overrides

--- a/gateway_provisioners/k8s.py
+++ b/gateway_provisioners/k8s.py
@@ -42,7 +42,11 @@ kpt_dir = os.environ.get("GP_POD_TEMPLATE_DIR", "/tmp")  # noqa: S108
 
 app_name = os.environ.get("GP_APP_NAME", "k8s-provisioner")
 
-if not os.environ.get("SPHINX_BUILD_IN_PROGRESS", ""):
+if (
+    "SPHINX_BUILD_IN_PROGRESS" not in os.environ
+    and "PYTEST_CURRENT_TEST" not in os.environ
+    and "PYTEST_RUN_CONFIG" not in os.environ
+):
     if bool(os.environ.get("GP_USE_INCLUSTER_CONFIG", "True").lower() == "true"):
         config.load_incluster_config()
     else:

--- a/gateway_provisioners/k8s.py
+++ b/gateway_provisioners/k8s.py
@@ -5,7 +5,7 @@
 import logging
 import os
 import re
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Set
 
 import urllib3
 from overrides import overrides
@@ -68,7 +68,7 @@ class KubernetesProvisioner(ContainerProvisionerBase):
         self.restarting = False
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         # Set env before superclass call so we see these in the debug output
 
         # Kubernetes relies on many internal env variables.  Since we're running in a k8s pod, we will
@@ -83,7 +83,7 @@ class KubernetesProvisioner(ContainerProvisionerBase):
         return kwargs
 
     @overrides
-    async def get_provisioner_info(self) -> dict[str, Any]:
+    async def get_provisioner_info(self) -> Dict[str, Any]:
         provisioner_info = await super().get_provisioner_info()
         provisioner_info.update(
             {
@@ -100,7 +100,7 @@ class KubernetesProvisioner(ContainerProvisionerBase):
         self.delete_kernel_namespace = provisioner_info["delete_ns"]
 
     @overrides
-    def get_initial_states(self) -> set[str]:
+    def get_initial_states(self) -> Set[str]:
         return {"Pending", "Running"}
 
     @overrides

--- a/gateway_provisioners/remote_provisioner.py
+++ b/gateway_provisioners/remote_provisioner.py
@@ -13,7 +13,7 @@ import time
 from abc import abstractmethod
 from enum import Enum
 from socket import AF_INET, SHUT_WR, SOCK_STREAM, socket, timeout
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 import pexpect
 from jupyter_client import (
@@ -68,6 +68,10 @@ class KernelChannel(Enum):
     )
 
 
+def gp_launch_kernel(cmd: list, **kwargs):
+    return launch_kernel(cmd, **kwargs)
+
+
 class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase):
     """Base class for remote provisioners."""
 
@@ -105,7 +109,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         pass
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         self.response_manager.register_event(self.kernel_id)
 
         cmd = self.kernel_spec.argv  # Build launch command, provide substitutions
@@ -140,10 +144,10 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         return kwargs
 
     @overrides
-    async def launch_kernel(self, cmd: list[str], **kwargs: Any) -> KernelConnectionInfo:
+    async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
 
         launch_kwargs = RemoteProvisionerBase._scrub_kwargs(kwargs)
-        self.local_proc = launch_kernel(cmd, **launch_kwargs)
+        self.local_proc = gp_launch_kernel(cmd, **launch_kwargs)
         self.pid = self.local_proc.pid
         self.ip = local_ip
 

--- a/gateway_provisioners/remote_provisioner.py
+++ b/gateway_provisioners/remote_provisioner.py
@@ -13,7 +13,7 @@ import time
 from abc import abstractmethod
 from enum import Enum
 from socket import AF_INET, SHUT_WR, SOCK_STREAM, socket, timeout
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pexpect
 from jupyter_client import (
@@ -217,7 +217,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         await self.shutdown_listener(restart)
 
     @overrides
-    async def get_provisioner_info(self) -> dict[str, Any]:
+    async def get_provisioner_info(self) -> Dict[str, Any]:
         provisioner_info = await super().get_provisioner_info()
         provisioner_info.update(
             {
@@ -250,7 +250,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         return recommended
 
     @overrides
-    def _finalize_env(self, env: dict[str, str]) -> None:
+    def _finalize_env(self, env: Dict[str, str]) -> None:
 
         # add the applicable kernel_id and language to the env dict
         env["KERNEL_ID"] = self.kernel_id
@@ -266,9 +266,9 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
             env.pop(k, None)
 
     @staticmethod
-    def _scrub_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    def _scrub_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Remove any keyword arguments that Popen does not tolerate."""
-        keywords_to_scrub: list[str] = ["extra_arguments", "kernel_id"]
+        keywords_to_scrub: List[str] = ["extra_arguments", "kernel_id"]
         scrubbed_kwargs = kwargs.copy()
         for kw in keywords_to_scrub:
             scrubbed_kwargs.pop(kw, None)
@@ -276,7 +276,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         return scrubbed_kwargs
 
     @abstractmethod
-    def log_kernel_launch(self, cmd: list[str]) -> None:
+    def log_kernel_launch(self, cmd: List[str]) -> None:
         """Logs the kernel launch from the respective remote provisioner"""
         pass
 
@@ -486,7 +486,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         )
         self.log_and_raise(PermissionError(error_message))
 
-    def _validate_port_range(self) -> tuple[int, int]:
+    def _validate_port_range(self) -> Tuple[int, int]:
         """Validates the port range configuration option to ensure appropriate values."""
 
         lower_port = upper_port = 0
@@ -854,7 +854,7 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
             )
             return pexpect.spawn(cmd, env=os.environ.copy().pop("SSH_ASKPASS", None))
 
-    def _select_ports(self, count: int) -> list[int]:
+    def _select_ports(self, count: int) -> List[int]:
         """
         Selects and returns n random ports that adhere to the configured port range, if applicable.
 
@@ -867,8 +867,8 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         -------
         List - ports available and adhering to the configured port range
         """
-        ports: list[int] = []
-        sockets: list[socket] = []
+        ports: List[int] = []
+        sockets: List[socket] = []
         for _i in range(count):
             sock = self._select_socket()
             ports.append(sock.getsockname()[1])

--- a/gateway_provisioners/yarn.py
+++ b/gateway_provisioners/yarn.py
@@ -8,7 +8,7 @@ import os
 import signal
 import socket
 import time
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from overrides import overrides
 from traitlets import Bool, Unicode, default
@@ -128,7 +128,7 @@ class YarnProvisioner(RemoteProvisionerBase):
         return self.local_proc is not None or self.application_id is not None
 
     @overrides
-    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+    async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
         self.application_id = None
         self.last_known_state = None
         self.candidate_queue = None
@@ -245,7 +245,7 @@ class YarnProvisioner(RemoteProvisionerBase):
         await super().cleanup(restart=restart)
 
     @overrides
-    async def get_provisioner_info(self) -> dict[str, Any]:
+    async def get_provisioner_info(self) -> Dict[str, Any]:
         provisioner_info = await super().get_provisioner_info()
         provisioner_info.update({"application_id": self.application_id})
         return provisioner_info
@@ -286,7 +286,7 @@ class YarnProvisioner(RemoteProvisionerBase):
                 self.detect_launch_failure()
 
     @overrides
-    def log_kernel_launch(self, cmd: list[str]) -> None:
+    def log_kernel_launch(self, cmd: List[str]) -> None:
         self.log.info(
             f"{self.__class__.__name__}: kernel launched. YARN RM: {self.rm_addr}, "
             f"pid: {self.local_proc.pid}, Kernel ID: {self.kernel_id}, cmd: '{cmd}'"
@@ -325,7 +325,7 @@ class YarnProvisioner(RemoteProvisionerBase):
             timeout_message = f"KernelID: '{self.kernel_id}' launch timeout due to: {reason}"
             self.log_and_raise(TimeoutError(timeout_message))
 
-    async def _shutdown_application(self) -> tuple[Optional[bool], str]:
+    async def _shutdown_application(self) -> Tuple[Optional[bool], str]:
         """Shuts down the YARN application, returning None if final state is confirmed, False otherwise."""
         result = False
         self._kill_app_by_id(self.application_id)
@@ -342,7 +342,7 @@ class YarnProvisioner(RemoteProvisionerBase):
 
         return result, state
 
-    def _confirm_yarn_queue_availability(self, **kwargs: dict[str, Any]) -> None:
+    def _confirm_yarn_queue_availability(self, **kwargs: Dict[str, Any]) -> None:
         """
         Submitting jobs to yarn queue and then checking till the jobs are in running state
         will lead to orphan jobs being created in some scenarios.
@@ -447,7 +447,7 @@ class YarnProvisioner(RemoteProvisionerBase):
             reason = f"Yarn Compute Resource is unavailable after {self.yarn_resource_check_wait_time} seconds"
             self.log_and_raise(TimeoutError(reason))
 
-    def _initialize_resource_manager(self, **kwargs: Optional[dict[str, Any]]) -> None:
+    def _initialize_resource_manager(self, **kwargs: Optional[Dict[str, Any]]) -> None:
         """Initialize the Hadoop YARN Resource Manager instance used for this kernel's lifecycle."""
 
         endpoints = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "jupyter_client>=7.2",
+    "jupyter_client>=7.4",
     "overrides",
     "paramiko>=2.4.0",
     "pexpect>=4.2.0",
     "pycryptodomex>=3.9.7",
-    "tornado>=6.1",
+    "tornado>=6.2",
     "traitlets>=5.1"
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
   "pytest-cov",
   "pytest-timeout",
   "pytest-tornasync",
+  "pytest-jupyter[server]>=0.4",
   # Install optional dependencies so all modules will load during collection
   "docker>=3.5.0",
   "yarn-api-client",
@@ -158,7 +159,10 @@ testpaths = [
 filterwarnings= [
   # Fail on warnings
   "error",
-#  "ignore:There is no current event loop:DeprecationWarning",
+  "ignore:zmq.eventloop.ioloop is deprecated in pyzmq 17:DeprecationWarning",
+  "ignore:There is no current event loop:DeprecationWarning",
+  # In PyPy/Cython: see https://github.com/yaml/pyyaml/issues/688
+  "ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,13 @@ Tracker = "https://github.com/gateway-experiments/gateway_provisioners/issues"
 
 [project.optional-dependencies]
 test = [
+  "importlib_metadata",
   "mock",
   "pre-commit",
   "pytest",
   "pytest-cov",
   "pytest-timeout",
+  "pytest-tornasync",
   # Install optional dependencies so all modules will load during collection
   "docker>=3.5.0",
   "yarn-api-client",
@@ -151,7 +153,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 addopts = "-raXs --durations 10 --color=yes --doctest-modules"
 testpaths = [
-    "gateway_provisioners/tests/"
+    "tests/"
 ]
 filterwarnings= [
   # Fail on warnings
@@ -210,3 +212,5 @@ unfixable = [
 [tool.ruff.per-file-ignores]
 # T201 `print` found
 "gateway_provisioners/cli/*" = ["T201"]
+# N802 Function name should be lowercase
+"tests/mocks/k8s_client.py" = ["N802"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4"]
+requires = ["hatchling>=1.11"]
 build-backend = "hatchling.build"
 
 [project]
@@ -125,6 +125,13 @@ features = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = "make -C docs html SPHINXOPTS='-W'"
 api = "sphinx-apidoc -o docs/source/api -f -E gateway_provisioners"
+
+[tool.hatch.envs.test]
+features = ["test"]
+[tool.hatch.envs.test.scripts]
+test = "python -m pytest -vv {args}"
+nowarn = "test -W default {args}"
+
 
 [tool.mypy]
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ testpaths = [
 filterwarnings= [
   # Fail on warnings
   "error",
+#  "ignore:There is no current event loop:DeprecationWarning",
 ]
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import os
 import sys
 from socket import socket
 
 import pytest
-import tornado
-import tornado.testing
 import yarn_api_client
 
 os.environ["PYTEST_CURRENT_TEST"] = "1"
@@ -35,23 +32,7 @@ from gateway_provisioners.response_manager import ResponseManager
 
 
 @pytest.fixture
-def asyncio_loop():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    yield loop
-    loop.close()
-
-
-@pytest.fixture(autouse=True)
-def io_loop(asyncio_loop):
-    async def get_tornado_loop():
-        return tornado.ioloop.IOLoop.current()
-
-    return asyncio_loop.run_until_complete(get_tornado_loop())
-
-
-@pytest.fixture
-def response_manager(io_loop, monkeypatch):
+def response_manager(monkeypatch):
     """Setup the Kernel Provisioner Factory, mocking the entrypoint fetch calls."""
     monkeypatch.setattr(ResponseManager, "register_event", mock_register_event)
     monkeypatch.setattr(socket, "listen", mock_socket_listen)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from jupyter_client.kernelspec import KernelSpec
 from jupyter_client.provisioning.factory import KernelProvisionerFactory
 from mocks.docker_client import mock_docker_from_env
 from mocks.k8s_client import MockK8sClient
-from mocks.proc import mock_launch_kernel
+from mocks.popen import mock_launch_kernel
 from mocks.response_manager import mock_get_connection_info, mock_register_event, mock_socket_listen
 from mocks.yarn_client import MockResourceManager
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import sys
+from socket import socket
+
+import pytest
+import yarn_api_client
+
+os.environ["PYTEST_CURRENT_TEST"] = "1"
+os.environ["JUPYTER_PLATFORM_DIRS"] = "1"  # Avoid deprecation warning and use the platform dirs now
+
+# See compatibility note on `group` keyword in https://docs.python.org/3/library/importlib.metadata.html#entry-points
+if sys.version_info < (3, 10):  # pragma: no cover
+    from importlib_metadata import EntryPoint, entry_points
+else:  # pragma: no cover
+    from importlib.metadata import EntryPoint, entry_points
+from docker.client import DockerClient
+from jupyter_client.kernelspec import KernelSpec
+from jupyter_client.provisioning.factory import KernelProvisionerFactory
+from mocks.docker_client import mock_docker_from_env
+from mocks.k8s_client import MockK8sClient
+from mocks.proc import mock_launch_kernel
+from mocks.response_manager import mock_get_connection_info, mock_register_event, mock_socket_listen
+from mocks.yarn_client import MockResourceManager
+
+import gateway_provisioners
+from gateway_provisioners.k8s import client  # noqa: F401
+from gateway_provisioners.remote_provisioner import RemoteProvisionerBase
+from gateway_provisioners.response_manager import ResponseManager
+
+
+@pytest.fixture
+def response_manager(monkeypatch):
+    """Setup the Kernel Provisioner Factory, mocking the entrypoint fetch calls."""
+    monkeypatch.setattr(ResponseManager, "register_event", mock_register_event)
+    monkeypatch.setattr(socket, "listen", mock_socket_listen)
+    monkeypatch.setattr(ResponseManager, "get_connection_info", mock_get_connection_info)
+    rm = ResponseManager.instance()
+
+    yield rm
+
+
+@pytest.fixture
+def init_api_mocks(monkeypatch):
+    monkeypatch.setattr(DockerClient, "from_env", mock_docker_from_env)
+    monkeypatch.setattr(yarn_api_client.resource_manager, "ResourceManager", MockResourceManager)
+    monkeypatch.setattr(
+        gateway_provisioners.remote_provisioner, "gp_launch_kernel", mock_launch_kernel
+    )
+    monkeypatch.setattr(gateway_provisioners.k8s, "client", MockK8sClient)
+
+
+@pytest.fixture
+def kernelspec():
+    def _kernelspec(name: str) -> KernelSpec:
+        kspec = KernelSpec()
+        kspec.argv = [
+            "--public-key:{public_key}",
+            "--response-address:{response_address}",
+            "--port-range:{port_range}",
+            "--kernel-id:{kernel_id}",
+        ]
+        kspec.display_name = f"{name}_python"
+        kspec.language = "python"
+        kspec.env = {}
+        kspec.metadata = {}
+        return kspec
+
+    return _kernelspec
+
+
+@pytest.fixture
+def get_provisioner(kernelspec):
+    def _get_provisioner(name: str, kernel_id: str) -> RemoteProvisionerBase:
+        provisioner_config = {}
+        provisioner_name = name + "-provisioner"
+        eps = entry_points(group=KernelProvisionerFactory.GROUP_NAME, name=provisioner_name)
+        assert eps, f"No entry_point was returned for provisioner '{provisioner_name}'!"
+        ep: EntryPoint = eps[provisioner_name]
+        provisioner_class = ep.load()
+        provisioner: RemoteProvisionerBase = provisioner_class(
+            kernel_id=kernel_id, kernel_spec=kernelspec(name), parent=None, **provisioner_config
+        )
+        return provisioner
+
+    return _get_provisioner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 import os
 import sys
 from socket import socket
 
 import pytest
+import tornado
+import tornado.testing
 import yarn_api_client
 
 os.environ["PYTEST_CURRENT_TEST"] = "1"
@@ -32,14 +35,30 @@ from gateway_provisioners.response_manager import ResponseManager
 
 
 @pytest.fixture
-def response_manager(monkeypatch):
+def asyncio_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(autouse=True)
+def io_loop(asyncio_loop):
+    async def get_tornado_loop():
+        return tornado.ioloop.IOLoop.current()
+
+    return asyncio_loop.run_until_complete(get_tornado_loop())
+
+
+@pytest.fixture
+def response_manager(io_loop, monkeypatch):
     """Setup the Kernel Provisioner Factory, mocking the entrypoint fetch calls."""
     monkeypatch.setattr(ResponseManager, "register_event", mock_register_event)
     monkeypatch.setattr(socket, "listen", mock_socket_listen)
     monkeypatch.setattr(ResponseManager, "get_connection_info", mock_get_connection_info)
     rm = ResponseManager.instance()
-
     yield rm
+    ResponseManager.clear_instance()
 
 
 @pytest.fixture

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.

--- a/tests/mocks/docker_client.py
+++ b/tests/mocks/docker_client.py
@@ -1,0 +1,130 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+class DockerResource:
+    """Track the current state of the resource"""
+
+    def __init__(self, env: dict):
+        self.env = env
+        self.kernel_id: str = env.get("KERNEL_ID")
+        self.kernel_username: str = env.get("KERNEL_USERNAME")
+        self.container_name = f"{self.kernel_username}-{self.kernel_id}"
+        self.docker_network = env.get("GP_DOCKER_NETWORK")
+        self.is_swarm = env.get("GP_DOCKER_MODE") == "swarm"
+        self.status: str = "created"
+        if self.is_swarm:
+            self.status = "preparing"
+        self.query_counter: int = 1
+
+
+docker_resources: dict = {}
+
+
+class MockService:
+    def __init__(self, resource: DockerResource):
+        self.resource = resource
+        self.name = resource.container_name
+        self.status = resource.status
+        self.attrs = {
+            "NetworkSettings": {
+                "IPAddress": "127.0.0.1",
+                "Networks": {resource.docker_network: {"IPAddress": "127.0.0.1"}},
+            }
+        }
+        task = {
+            "ID": hash(self.resource.kernel_id),
+            "Status": {"State": self.resource.status},
+            "NetworksAttachments": [{"Addresses": ["127.0.0.1/xxx"]}],
+        }
+        self.task_list: list = [task]
+
+    def tasks(self, **kwargs):
+        return self.task_list
+
+
+class MockServiceCollection:  # (ServiceCollection):
+    def __init__(self, **kwargs):
+        pass
+
+    def list(self, **kwargs):
+        """Get a collection of Containers"""
+        # This will be called with a filters object, the "label" key of
+        # which contains the kernel_id, so we need to pick that out to
+        # locate the appropriate entry:
+        # {"label": "kernel_id=" + self.kernel_id}"
+
+        services = []
+        label = kwargs.get("filters", {}).get("label", "")
+        assert label, "No label found in filters - can't list containers!"
+        kernel_id = label.split("=")[1]
+        if kernel_id in docker_resources:
+            resource = docker_resources.get(kernel_id)
+            if resource.query_counter >= 3:  # time to return
+                resource.status = "running"
+                service = MockService(resource)
+                services.append(service)
+            else:
+                resource.status = "starting"
+            resource.query_counter += 1
+
+        return services
+
+
+class MockContainer:
+    def __init__(self, resource: DockerResource):
+        self.resource = resource
+        self.name = resource.container_name
+        self.status = resource.status
+        self.attrs = {
+            "NetworkSettings": {
+                "IPAddress": "127.0.0.1",
+                "Networks": {resource.docker_network: {"IPAddress": "127.0.0.1"}},
+            }
+        }
+
+    def remove(self, **kwargs):
+        docker_resources.pop(self.resource.kernel_id)
+
+
+class MockContainerCollection:  # (ContainerCollection):
+    def __init__(self, **kwargs):
+        pass
+
+    def list(self, **kwargs):
+        """Get a collection of Containers"""
+        # This will be called with a filters object, the "label" key of
+        # which contains the kernel_id, so we need to pick that out to
+        # locate the appropriate entry:
+        # {"label": "kernel_id=" + self.kernel_id}"
+
+        containers = []
+        label = kwargs.get("filters", {}).get("label", "")
+        assert label, "No label found in filters - can't list containers!"
+        kernel_id = label.split("=")[1]
+        if kernel_id in docker_resources:
+            resource = docker_resources.get(kernel_id)
+            if resource.query_counter >= 3:  # time to return
+                resource.status = "running"
+                container = MockContainer(resource)
+                containers.append(container)
+            resource.query_counter += 1
+
+        return containers
+
+
+class MockDockerClient:  # (DockerClient):
+    def __init__(self, **kwargs):
+        pass
+
+    @property
+    def containers(self):
+        return MockContainerCollection(client=self)
+
+    @property
+    def services(self):
+        return MockServiceCollection(client=self)
+
+
+def mock_docker_from_env():  # -> DockerClient:
+    return MockDockerClient()

--- a/tests/mocks/docker_client.py
+++ b/tests/mocks/docker_client.py
@@ -42,6 +42,9 @@ class MockService:
     def tasks(self, **kwargs):
         return self.task_list
 
+    def remove(self, **kwargs):
+        docker_resources.pop(self.resource.kernel_id)
+
 
 class MockServiceCollection:  # (ServiceCollection):
     def __init__(self, **kwargs):

--- a/tests/mocks/k8s_client.py
+++ b/tests/mocks/k8s_client.py
@@ -1,0 +1,108 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from dataclasses import dataclass
+
+from kubernetes.client.rest import ApiException
+
+
+class K8sResource:
+    """Track the current state of the resource"""
+
+    def __init__(self, env: dict):
+        self.env = env
+        self.kernel_id: str = env.get("KERNEL_ID")
+        self.kernel_username: str = env.get("KERNEL_USERNAME")
+        self.pod_name = f"{self.kernel_username}-{self.kernel_id}"
+        self.namespace: str = env.get("KERNEL_NAMESPACE")
+        self.status: str = "Pending"
+        self.query_counter: int = 1
+
+
+k8s_resources: dict = {}
+
+
+@dataclass
+class MockPodStatus:
+    pod_ip: str
+    host_ip: str
+    phase: str
+
+
+@dataclass
+class MockPodMetadata:
+    name: str
+
+
+@dataclass
+class MockPodInfo:
+    status: MockPodStatus
+    metadata: MockPodMetadata
+
+
+class MockResponse:
+    def __init__(self, pod_info: MockPodInfo):
+        self.items: list[MockPodInfo] = []
+        self.items.append(pod_info)
+
+
+class MockCoreV1Api:  # (CoreV1Api):
+    def __init__(self, **kwargs):
+        pass
+
+    def list_namespaced_pod(self, namespace, **kwargs):
+        kernel_id: str = ""
+        label_selector = kwargs.get("label_selector", "")
+        selector_entries = label_selector.split(",")
+        for entry in selector_entries:
+            if entry.startswith("kernel_id="):
+                kernel_id = entry.split("=")[1]
+                break
+        if kernel_id in k8s_resources:
+            resource = k8s_resources.get(kernel_id)
+            if resource.query_counter >= 3:  # time to return
+                resource.status = "Running"
+                pod_info = MockPodInfo(
+                    status=MockPodStatus("127.0.0.1", "127.0.0.1", resource.status),
+                    metadata=MockPodMetadata(name=resource.pod_name),
+                )
+                response = MockResponse(pod_info=pod_info)
+                return response
+            else:
+                resource.status = "Pending"
+                resource.query_counter += 1
+
+        return None
+
+    def delete_namespaced_pod(self, name, namespace, **kwargs):
+        pod_info = None
+        delete_resource = None
+        for kid, resource in k8s_resources.items():
+            if resource.pod_name == name:
+                resource.status = "Terminating"
+                delete_resource = kid
+                pod_info = MockPodInfo(
+                    status=MockPodStatus("127.0.0.1", "127.0.0.1", resource.status),
+                    metadata=MockPodMetadata(name=resource.pod_name),
+                )
+                break
+
+        if pod_info:
+            k8s_resources.pop(delete_resource)
+            return pod_info
+
+        raise ApiException(status=404, reason="Could not find resource with pod-name: '{name}'!")
+
+
+class MockK8sClient:
+    def __init__(self, **kwargs):
+        self.args = kwargs
+        pass
+
+    @classmethod
+    def CoreV1Api(cls):
+        return MockCoreV1Api()
+
+    @classmethod
+    def V1DeleteOptions(cls, grace_period_seconds=0, propagation_policy="Background") -> dict:
+        return {"grace_period_seconds": 0, "propagation_policy": "Background"}

--- a/tests/mocks/k8s_client.py
+++ b/tests/mocks/k8s_client.py
@@ -46,10 +46,7 @@ class MockResponse:
         self.items.append(pod_info)
 
 
-class MockCoreV1Api:  # (CoreV1Api):
-    def __init__(self, **kwargs):
-        pass
-
+class MockCoreV1Api:
     def list_namespaced_pod(self, namespace, **kwargs):
         kernel_id: str = ""
         label_selector = kwargs.get("label_selector", "")
@@ -93,6 +90,20 @@ class MockCoreV1Api:  # (CoreV1Api):
 
         raise ApiException(status=404, reason="Could not find resource with pod-name: '{name}'!")
 
+    def delete_namespace(self, name, body):
+        # TODO - add impl when adding namespace lifecycle testing
+        pass
+
+    def create_namespace(self, body):
+        # TODO - add impl when adding namespace lifecycle testing
+        pass
+
+
+class MockRbacAuthorizationV1Api:
+    def create_namespaced_role_binding(self, namespace, body):
+        # TODO - add impl when adding namespace lifecycle testing
+        pass
+
 
 class MockK8sClient:
     def __init__(self, **kwargs):
@@ -104,5 +115,29 @@ class MockK8sClient:
         return MockCoreV1Api()
 
     @classmethod
+    def RbacAuthorizationV1Api(cls):
+        return MockRbacAuthorizationV1Api()
+
+    @classmethod
     def V1DeleteOptions(cls, grace_period_seconds=0, propagation_policy="Background") -> dict:
         return {"grace_period_seconds": 0, "propagation_policy": "Background"}
+
+    @classmethod
+    def V1ObjectMeta(cls, name, labels) -> dict:
+        pass
+
+    @classmethod
+    def V1Namespace(cls, metadata) -> dict:
+        pass
+
+    @classmethod
+    def V1RoleRef(cls, api_group, name) -> dict:
+        pass
+
+    @classmethod
+    def V1Subject(cls, api_group, kind, name, namespace) -> dict:
+        pass
+
+    @classmethod
+    def V1RoleBinding(cls, kind, metadata, role_ref, subjects) -> dict:
+        pass

--- a/tests/mocks/k8s_client.py
+++ b/tests/mocks/k8s_client.py
@@ -108,7 +108,6 @@ class MockRbacAuthorizationV1Api:
 class MockK8sClient:
     def __init__(self, **kwargs):
         self.args = kwargs
-        pass
 
     @classmethod
     def CoreV1Api(cls):

--- a/tests/mocks/popen.py
+++ b/tests/mocks/popen.py
@@ -13,25 +13,36 @@ class MockPopen(Popen):
         self.cmd = cmd
         self.args = kwargs
         self.env = kwargs.get("env")
+        self.kernel_id = self.env.get("KERNEL_ID")
+        self.resources = None
         self.pid = 42
 
-    def wait(self):
+    def wait(self, timeout=None):
+        # This is called at cleanup and a good time to clear our resource cache
+        assert self.resources
+        self.resources.pop(self.kernel_id)
         return None
 
     def poll(self):
-        return None
+        # Ensure the resource still exits, else return non-None
+        if self.resources and self.kernel_id in self.resources:
+            return None
+        return 2
 
     def mock_resources(self):
         """Sets up the initial resource (application, container) for discovery and state management"""
         if "GP_DOCKER_MODE" in self.env:  # This is docker, which one?
             resource = DockerResource(env=self.env)
             docker_resources[resource.kernel_id] = resource
+            self.resources = docker_resources
         elif "KERNEL_POD_NAME" in self.env:  # This is k8s
             resource = K8sResource(env=self.env)
             k8s_resources[resource.kernel_id] = resource
+            self.resources = k8s_resources
         elif "GP_IMPERSONATION_ENABLED" in self.env:  # This is yarn (but a little fragile)
             resource = YarnResource(env=self.env)
             yarn_resources[resource.kernel_id] = resource
+            self.resources = yarn_resources
         else:
             err_msg = "Cant determine resource to mock!"
             raise AssertionError(err_msg)

--- a/tests/mocks/proc.py
+++ b/tests/mocks/proc.py
@@ -1,0 +1,43 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from subprocess import Popen
+
+from .docker_client import DockerResource, docker_resources
+from .k8s_client import K8sResource, k8s_resources
+from .yarn_client import YarnResource, yarn_resources
+
+
+class MockPopen(Popen):
+    def __init__(self, cmd: list, **kwargs):
+        self.cmd = cmd
+        self.args = kwargs
+        self.env = kwargs.get("env")
+        self.pid = 42
+
+    def wait(self):
+        return None
+
+    def poll(self):
+        return None
+
+    def mock_resources(self):
+        """Sets up the initial resource (application, container) for discovery and state management"""
+        if "GP_DOCKER_MODE" in self.env:  # This is docker, which one?
+            resource = DockerResource(env=self.env)
+            docker_resources[resource.kernel_id] = resource
+        elif "KERNEL_POD_NAME" in self.env:  # This is k8s
+            resource = K8sResource(env=self.env)
+            k8s_resources[resource.kernel_id] = resource
+        elif "GP_IMPERSONATION_ENABLED" in self.env:  # This is yarn (but a little fragile)
+            resource = YarnResource(env=self.env)
+            yarn_resources[resource.kernel_id] = resource
+        else:
+            err_msg = "Cant determine resource to mock!"
+            raise AssertionError(err_msg)
+
+
+def mock_launch_kernel(cmd: list, **kwargs) -> Popen:
+    proc = MockPopen(cmd, **kwargs)
+    proc.mock_resources()
+    return proc

--- a/tests/mocks/response_manager.py
+++ b/tests/mocks/response_manager.py
@@ -1,0 +1,37 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+response_manager_registration = {}
+
+
+def generate_connection_info(id: str) -> dict:
+    comm_port = hash(id) % 65535
+    return {
+        "comm_port": comm_port,
+        "shell_port": comm_port + 1,
+        "iopub_port": comm_port + 2,
+        "stdin_port": comm_port + 3,
+        "control_port": comm_port + 4,
+        "hb_port": comm_port + 5,
+        "ip": "127.0.0.1",
+        "key": id.replace("-", ""),
+        "transport": "tcp",
+        "signature_scheme": "hmac-sha256",
+        "kernel_name": "python3",
+    }
+
+
+# This avoids the response manager from listening for requests and
+# an annoying prompt in debug mode.
+def mock_socket_listen(self, backlog: int) -> None:
+    pass
+
+
+def mock_register_event(self, kernel_id: str) -> None:
+    assert kernel_id not in response_manager_registration
+    response_manager_registration[kernel_id] = {}
+
+
+async def mock_get_connection_info(self, kernel_id: str) -> dict:
+    assert kernel_id in response_manager_registration
+    return generate_connection_info(kernel_id)

--- a/tests/mocks/yarn_client.py
+++ b/tests/mocks/yarn_client.py
@@ -44,7 +44,6 @@ class MockResourceManager:
 
     def __init__(self, **kwargs):
         self.endpoints = kwargs.get("service_endpoints")
-        pass
 
     def get_active_endpoint(self):
         assert len(self.endpoints) > 0

--- a/tests/mocks/yarn_client.py
+++ b/tests/mocks/yarn_client.py
@@ -1,0 +1,114 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from time import time_ns
+from typing import Optional
+
+
+class YarnResource:
+    """Track the current state of the resource"""
+
+    initial_states = {"NEW", "SUBMITTED", "ACCEPTED", "RUNNING"}
+    final_states = {"FINISHED", "KILLED", "FAILED"}
+
+    def __init__(self, env: dict):
+        self.env = env
+        self.kernel_id: str = env.get("KERNEL_ID")
+        self.kernel_username: str = env.get("KERNEL_USERNAME")
+        self.name = self.kernel_id
+        self.id = f"application_{str(time_ns())}_0001"
+        self.status: str = "NEW"
+        self.query_counter: int = 1
+
+
+yarn_resources: dict = {}
+
+
+class MockResponse:
+    def __init__(
+        self, apps: Optional[dict] = None, app: Optional[dict] = None, status: Optional[str] = None
+    ):
+        self.data = {}
+        if apps:
+            self.data["apps"] = apps
+        elif app:
+            self.data["app"] = app
+        elif status:
+            self.data["status"] = status
+
+
+class MockResourceManager:  # (ResourceManager):
+    def __init__(self, **kwargs):
+        pass
+
+    def get_active_endpoint(self):
+        pass
+
+    def cluster_applications(
+        self,
+        state=None,
+        states=None,
+        final_status=None,
+        user=None,
+        queue=None,
+        limit=None,
+        started_time_begin=None,
+        started_time_end=None,
+        finished_time_begin=None,
+        finished_time_end=None,
+        application_types=None,
+        application_tags=None,
+        name=None,
+        de_selects=None,
+    ):
+        """This method is used to determine when the application ID has been created"""
+        apps = {"app": []}
+        app_list = apps.get("app")
+        for kid, resource in yarn_resources.items():
+            # convert each resource into an app list entry
+            id = ""
+            if resource.query_counter >= 3:
+                id = resource.id
+                resource.status = "RUNNING"
+            resource.query_counter += 1
+            app_entry: dict = {"name": kid, "id": id, "state": resource.status}
+            app_list.append(app_entry)
+        response = MockResponse(apps=apps)
+        return response
+
+    def cluster_application(self, application_id):
+        response = MockResponse()
+        resource = self._locate_resource(application_id)
+        if resource:
+            app_entry: dict = {
+                "name": resource.kernel_id,
+                "id": resource.id,
+                "state": resource.status,
+                "amHostHttpAddress": "localhost:8042",
+            }
+            response.data["app"] = app_entry
+
+        return response
+
+    def cluster_application_state(self, application_id):
+        response = MockResponse()
+        resource = self._locate_resource(application_id)
+        if resource:
+            response.data["state"] = resource.status
+
+        return response
+
+    def cluster_application_kill(self, application_id):
+        pass
+
+    def cluster_node_container_memory(self):
+        pass
+
+    def cluster_scheduler_queue(self, yarn_queue_name):
+        pass
+
+    def _locate_resource(self, app_id: str) -> Optional[YarnResource]:
+        for resource in yarn_resources.values():
+            if resource.id == app_id:
+                return resource
+        return None

--- a/tests/test_docker_provisioners.py
+++ b/tests/test_docker_provisioners.py
@@ -1,0 +1,48 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from uuid import uuid4
+
+import pytest
+from jupyter_client import KernelConnectionInfo
+from utils import TEST_USER, ValidatorBase
+
+
+@pytest.mark.parametrize(
+    "name,seed_env",
+    [("docker", {"KERNEL_USERNAME": TEST_USER}), ("docker-swarm", {"KERNEL_USERNAME": TEST_USER})],
+)
+async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, name, seed_env):
+
+    kernel_id = str(uuid4())
+    validator = ValidatorBase.create_instance(
+        name, seed_env, kernel_id=kernel_id, response_manager=response_manager
+    )
+
+    provisioner = get_provisioner(name, kernel_id)
+    validator.validate_provisioner(provisioner)
+
+    kwargs = {"env": seed_env}
+    kwargs = await provisioner.pre_launch(**kwargs)
+    validator.validate_pre_launch(kwargs)
+
+    cmd = kwargs.pop("cmd")
+    connection_info: KernelConnectionInfo = await provisioner.launch_kernel(cmd, **kwargs)
+    validator.validate_launch_kernel(connection_info)
+
+    # post-launch()
+
+    # has_kernel()
+
+    # poll()
+
+    # send_signal()? only tests remote provisioner, need to mock connection port
+    #  mock _send_signal_via_listener()
+
+    # kill()
+
+    # terminate()
+
+    # shutdown_requested()
+
+    # cleanup()

--- a/tests/test_docker_provisioners.py
+++ b/tests/test_docker_provisioners.py
@@ -1,11 +1,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 from uuid import uuid4
 
 import pytest
 from jupyter_client import KernelConnectionInfo
-from utils import TEST_USER, ValidatorBase
+from validators import TEST_USER, ValidatorBase
 
 
 @pytest.mark.parametrize(
@@ -18,6 +19,7 @@ async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, name
     validator = ValidatorBase.create_instance(
         name, seed_env, kernel_id=kernel_id, response_manager=response_manager
     )
+    os.environ.update(seed_env)
 
     provisioner = get_provisioner(name, kernel_id)
     validator.validate_provisioner(provisioner)
@@ -30,19 +32,21 @@ async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, name
     connection_info: KernelConnectionInfo = await provisioner.launch_kernel(cmd, **kwargs)
     validator.validate_launch_kernel(connection_info)
 
-    # post-launch()
+    await provisioner.post_launch(**kwargs)
+    validator.validate_post_launch(kwargs)
 
-    # has_kernel()
+    assert provisioner.has_process is True, "has_process property has unexpected value: False"
 
-    # poll()
+    poll_result = await provisioner.poll()
+    assert poll_result is None, f"poll() returned unexpected result: '{poll_result}'"
 
-    # send_signal()? only tests remote provisioner, need to mock connection port
-    #  mock _send_signal_via_listener()
+    # send_signal()? only tests remote provisioner and probably better-suited for launcher tests
 
-    # kill()
+    # In the container-based provisioners, kill and terminate are identical, so only testing terminate.
 
-    # terminate()
+    await provisioner.terminate()
 
-    # shutdown_requested()
+    # shutdown_requested() would only test remote provisioner and probably better-suited for launcher tests
 
-    # cleanup()
+    await provisioner.cleanup(restart=False)
+    assert provisioner.has_process is False, "has_process property has unexpected value: True"

--- a/tests/test_k8s_provisioners.py
+++ b/tests/test_k8s_provisioners.py
@@ -1,0 +1,46 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from uuid import uuid4
+
+import pytest
+from jupyter_client import KernelConnectionInfo
+from utils import TEST_USER, K8sValidator
+
+
+@pytest.mark.parametrize("seed_env", [{"KERNEL_USERNAME": TEST_USER}])
+async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, seed_env):
+
+    name = "kubernetes"
+    kernel_id = str(uuid4())
+    validator = K8sValidator.create_instance(
+        name, seed_env, kernel_id=kernel_id, response_manager=response_manager
+    )
+
+    provisioner = get_provisioner(name, kernel_id)
+    validator.validate_provisioner(provisioner)
+
+    kwargs = {"env": seed_env}
+    kwargs = await provisioner.pre_launch(**kwargs)
+    validator.validate_pre_launch(kwargs)
+
+    cmd = kwargs.pop("cmd")
+    connection_info: KernelConnectionInfo = await provisioner.launch_kernel(cmd, **kwargs)
+    validator.validate_launch_kernel(connection_info)
+
+    # post-launch()
+
+    # has_kernel()
+
+    # poll()
+
+    # send_signal()? only tests remote provisioner, need to mock connection port
+    #  mock _send_signal_via_listener()
+
+    # kill()
+
+    # terminate()
+
+    # shutdown_requested()
+
+    # cleanup()

--- a/tests/test_yarn_provisioners.py
+++ b/tests/test_yarn_provisioners.py
@@ -1,0 +1,46 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from uuid import uuid4
+
+import pytest
+from jupyter_client import KernelConnectionInfo
+from utils import TEST_USER, YarnValidator
+
+
+@pytest.mark.parametrize("seed_env", [{"KERNEL_USERNAME": TEST_USER}])
+async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, seed_env):
+
+    name = "yarn"
+    kernel_id = str(uuid4())
+    validator = YarnValidator.create_instance(
+        name, seed_env, kernel_id=kernel_id, response_manager=response_manager
+    )
+
+    provisioner = get_provisioner(name, kernel_id)
+    validator.validate_provisioner(provisioner)
+
+    kwargs = {"env": seed_env}
+    kwargs = await provisioner.pre_launch(**kwargs)
+    validator.validate_pre_launch(kwargs)
+
+    cmd = kwargs.pop("cmd")
+    connection_info: KernelConnectionInfo = await provisioner.launch_kernel(cmd, **kwargs)
+    validator.validate_launch_kernel(connection_info)
+
+    # post-launch()
+
+    # has_kernel()
+
+    # poll()
+
+    # send_signal()? only tests remote provisioner, need to mock connection port
+    #  mock _send_signal_via_listener()
+
+    # kill()
+
+    # terminate()
+
+    # shutdown_requested()
+
+    # cleanup()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,108 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from typing import Optional
+
+from jupyter_client.kernelspec import KernelSpec
+from mocks.response_manager import generate_connection_info
+
+from gateway_provisioners.remote_provisioner import RemoteProvisionerBase
+from gateway_provisioners.response_manager import ResponseManager
+
+TEST_USER = "test-user"
+
+
+class ValidatorBase:
+    @classmethod
+    def create_instance(cls, name: str, seed_env: dict, **kwargs):
+        if name == "kubernetes":
+            return K8sValidator(name=name, seed_env=seed_env, **kwargs)
+        if name == "yarn":
+            return YarnValidator(name=name, seed_env=seed_env, **kwargs)
+        if name == "docker":
+            return DockerValidator(name=name, seed_env=seed_env, **kwargs)
+        if name == "docker-swarm":
+            return DockerSwarmValidator(name=name, seed_env=seed_env, **kwargs)
+        err_msg = f"Invalid name '{name}' encountered!"
+        raise AssertionError(err_msg)
+
+    def __init__(self, name: str, seed_env: dict, **kwargs):
+        self.name: str = name
+        self.seed_env: dict = seed_env
+        self.kernel_id: str = kwargs.get("kernel_id")
+        self.response_manager: ResponseManager = kwargs.get("response_manager")
+        self.kernel_spec: Optional[KernelSpec] = None
+
+    def validate_provisioner(self, provisioner: RemoteProvisionerBase) -> None:
+        assert provisioner.kernel_id == self.kernel_id
+        assert provisioner.response_manager == self.response_manager
+        assert not provisioner.kernel_username
+        assert provisioner.kernel_spec.language == "python"
+        self.kernel_spec = provisioner.kernel_spec
+
+    def validate_pre_launch(self, kwargs: dict) -> None:
+        cmd: list = kwargs.get("cmd")
+        assert cmd is not None
+        assert f"--kernel-id:{self.kernel_id}" in cmd
+        assert "--port-range:0..0" in cmd
+        assert f"--response-address:{self.response_manager.response_address}" in cmd
+        assert f"--public-key:{self.response_manager.public_key}" in cmd
+
+        env: dict = kwargs.get("env")
+        assert env is not None
+        assert env["KERNEL_ID"] == self.kernel_id
+        assert env["KERNEL_USERNAME"] == TEST_USER
+        assert env["KERNEL_LANGUAGE"] == self.kernel_spec.language
+
+    def validate_launch_kernel(self, connection_info: dict) -> None:
+        assert connection_info == generate_connection_info(self.kernel_id)
+
+
+class YarnValidator(ValidatorBase):
+    """Handles validation of YarnProvisioners"""
+
+    def validate_pre_launch(self, kwargs: dict):
+        super().validate_pre_launch(kwargs)
+
+        env: dict = kwargs.get("env")
+        assert env["GP_IMPERSONATION_ENABLED"] == "False"
+
+
+class K8sValidator(ValidatorBase):
+    """Handles validation of KubernetesProvisioners"""
+
+    def validate_pre_launch(self, kwargs: dict):
+        super().validate_pre_launch(kwargs)
+
+        env: dict = kwargs.get("env")
+        assert env["KERNEL_UID"] == "1000"
+        assert env["KERNEL_GID"] == "100"
+        assert env["KERNEL_POD_NAME"] == f"{TEST_USER}-{self.kernel_id}"
+        assert env["KERNEL_NAMESPACE"] == "default"
+        assert env["KERNEL_SERVICE_ACCOUNT_NAME"] == "default"
+
+
+class DockerValidator(ValidatorBase):
+    """Handles validation of DockerProvisioners"""
+
+    def validate_pre_launch(self, kwargs: dict):
+        super().validate_pre_launch(kwargs)
+
+        env: dict = kwargs.get("env")
+        assert env["KERNEL_UID"] == "1000"
+        assert env["KERNEL_GID"] == "100"
+        assert env["GP_DOCKER_NETWORK"] == "bridge"
+        assert env["GP_DOCKER_MODE"] == "docker"
+
+
+class DockerSwarmValidator(ValidatorBase):
+    """Handles validation of DockerSwarmProvisioners"""
+
+    def validate_pre_launch(self, kwargs: dict):
+        super().validate_pre_launch(kwargs)
+
+        env: dict = kwargs.get("env")
+        assert env["KERNEL_UID"] == "1000"
+        assert env["KERNEL_GID"] == "100"
+        assert env["GP_DOCKER_NETWORK"] == "bridge"
+        assert env["GP_DOCKER_MODE"] == "swarm"


### PR DESCRIPTION
This pull request adds the initial test framework and a majority of the mocks necessary to test provisioners on Yarn, Kubernetes, and Docker{,Swarm}.

We will not close #21 at this time, but this does satisfy a checkbox or two on that issue.